### PR TITLE
Fix bug when importing files encoded in UTF-8 with Byte Order Mark

### DIFF
--- a/rs-csv-helper.php
+++ b/rs-csv-helper.php
@@ -1,9 +1,9 @@
 <?php
 
 class RS_CSV_Helper {
-	
+
 	const DELIMITER = ",";
-	
+
 	// File utility functions
 	public function fopen($filename, $mode='r') {
 		return fopen($filename, $mode);
@@ -16,22 +16,27 @@ class RS_CSV_Helper {
 	public function fclose($fp) {
 		return fclose($fp);
  	}
-	
+
 	public function parse_columns(&$obj, $array) {
 		if (!is_array($array) || count($array) == 0)
 			return false;
-		
+
+		$bom = pack("CCC", 0xef, 0xbb, 0xbf);
+		if (0 == strncmp($array[0], $bom, 3)) {
+		    $array[0] = substr($array[0], 3);
+		}
+
 		$keys = array_keys($array);
 		$values = array_values($array);
-		
+
 		$obj->column_indexes = array_combine($values, $keys);
 		$obj->column_keys = array_combine($keys, $values);
 	}
-	
+
 	public function get_data($obj, &$array, $key) {
 		if (!isset($obj->column_indexes) || !is_array($array) || count($array) == 0)
 			return false;
-		
+
 		if (isset($obj->column_indexes[$key])) {
 			$index = $obj->column_indexes[$key];
 			if (isset($array[$index]) && !empty($array[$index])) {
@@ -42,8 +47,8 @@ class RS_CSV_Helper {
 				unset($array[$index]);
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 }


### PR DESCRIPTION
I have had problems when importing a CSV file which was encoded in UTF-8 but included Byte Order Mark.
Just wrote a fix that strips the initial bytes of it if present. You may be interested in merging. 
