### PR TITLE
Feature filter thumbnail

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -209,6 +209,35 @@ function really_simple_csv_importer_save_tax_filter( $tax, $post, $is_update ) {
 add_filter( 'really_simple_csv_importer_save_tax', 'really_simple_csv_importer_save_tax_filter', 10, 3 );
 `
 
+= really_simple_csv_importer_save_thumbnail =
+
+This filter is applied to thumbnail data.
+
+Parameters:
+
+* `$thumbnail` - (string)(required) the thumbnail file path or distant URL
+* `$post` - (array) post data
+* `$is_update` - (bool)
+
+Example:
+
+`
+function really_simple_csv_importer_save_thumbnail_filter( $thumbnail, $post, $is_update ) {
+
+	// Import a local file from an FTP directory
+	if (!empty($thumbnail) && file_exists($thumbnail)) {
+		$upload_dir   = wp_upload_dir();
+		$target_path  = $upload_dir['path'] . DIRECTORY_SEPARATOR . basename($thumbnail);
+		if (copy($thumbnail, $target_path)) {
+			$thumbnail = $target_path;
+		}
+	}
+
+	return $thumbnail;
+}
+add_filter( 'really_simple_csv_importer_save_thumbnail', 'really_simple_csv_importer_save_thumbnail_filter', 10, 3 );
+`
+
 == How to customize the post data after importing to database ==
 
 = really_simple_csv_importer_post_saved =

--- a/readme.txt
+++ b/readme.txt
@@ -215,25 +215,25 @@ This filter is applied to thumbnail data.
 
 Parameters:
 
-* `$thumbnail` - (string)(required) the thumbnail file path or distant URL
+* `$post_thumbnail` - (string)(required) the thumbnail file path or distant URL
 * `$post` - (array) post data
 * `$is_update` - (bool)
 
 Example:
 
 `
-function really_simple_csv_importer_save_thumbnail_filter( $thumbnail, $post, $is_update ) {
+function really_simple_csv_importer_save_thumbnail_filter( $post_thumbnail, $post, $is_update ) {
 
 	// Import a local file from an FTP directory
-	if (!empty($thumbnail) && file_exists($thumbnail)) {
+	if (!empty($post_thumbnail) && file_exists($post_thumbnail)) {
 		$upload_dir   = wp_upload_dir();
-		$target_path  = $upload_dir['path'] . DIRECTORY_SEPARATOR . basename($thumbnail);
-		if (copy($thumbnail, $target_path)) {
-			$thumbnail = $target_path;
+		$target_path  = $upload_dir['path'] . DIRECTORY_SEPARATOR . basename($post_thumbnail);
+		if (copy($post_thumbnail, $target_path)) {
+			$post_thumbnail = $target_path;
 		}
 	}
 
-	return $thumbnail;
+	return $post_thumbnail;
 }
 add_filter( 'really_simple_csv_importer_save_thumbnail', 'really_simple_csv_importer_save_thumbnail_filter', 10, 3 );
 `

--- a/rs-csv-importer.php
+++ b/rs-csv-importer.php
@@ -328,7 +328,15 @@ class RS_CSV_Importer extends WP_Importer {
 				 * @param bool $is_update
 				 */
 				$tax = apply_filters( 'really_simple_csv_importer_save_tax', $tax, $post, $is_update );
-				
+				/**
+				 * Filter thumbnail URL or path.
+				 *
+				 * @param string $post_thumbnail (required)
+				 * @param array $post
+				 * @param bool $is_update
+				 */
+				$post_thumbnail = apply_filters( 'really_simple_csv_importer_save_thumbnail', $post_thumbnail, $post, $is_update );
+
 				/**
 				 * Option for dry run testing
 				 *


### PR DESCRIPTION
Hello Takuro, and many thanks for this great (clear & simple) plugin!

For a personal need, I figured out that it was not possible to act on the `post_thumbnail` value before actually attach it to a post. As I saw a few questions in the plugin's support about that, here is my little contribution: a new filter named *really_simple_csv_importer_save_thumbnail* with the following signature:

```php
really_simple_csv_importer_save_thumbnail ( $post_thumbnail, $post, $is_update ) : string
```

The idea is just to let the user act on the thumbnail extracted value if required and return a new one. I added a documentation block in the reamde with an example of usage.

I trigger it after the original three 'pre-save' filters (not sure about where it should be) ...

Hope this can help.