### PR TITLE
Change action from plugins_loaded to after_setup_theme

### DIFF
--- a/rs-csv-importer.php
+++ b/rs-csv-importer.php
@@ -493,7 +493,7 @@ function really_simple_csv_importer() {
     $rs_csv_importer = new RS_CSV_Importer();
     register_importer('csv', __('CSV', 'really-simple-csv-importer'), __('Import posts, categories, tags, custom fields from simple csv file.', 'really-simple-csv-importer'), array ($rs_csv_importer, 'dispatch'));
 }
-add_action( 'plugins_loaded', 'really_simple_csv_importer' );
+add_action( 'after_setup_theme', 'really_simple_csv_importer' );
 
 function really_simple_csv_importer_enqueue($hook) {
 	if ( 'admin.php' != $hook ) {


### PR DESCRIPTION
There are some setups where you load the plugin inside the theme. In those cases, the importer is not setup, I think it would be better to use after_setup_theme as the action to hook into.