### PR TITLE
Add filter to override the RS_CSV_Helper class

### DIFF
--- a/rs-csv-importer.php
+++ b/rs-csv-importer.php
@@ -135,25 +135,25 @@ class RS_CSV_Importer extends WP_Importer {
 		} else {
 			$h = RSCSV_Import_Post_Helper::add($post);
 		}
-
+		
 		// Set post tags
 		if (isset($post_tags)) {
 			$h->setPostTags($post_tags);
 		}
-
+		
 		// Set meta data
 		$h->setMeta($meta);
-
+		
 		// Set terms
 		foreach ($terms as $key => $value) {
 			$h->setObjectTerms($key, $value);
 		}
-
+		
 		// Add thumbnail
 		if ($thumbnail) {
 			$h->addThumbnail($thumbnail);
 		}
-
+		
 		return $h;
 	}
 

--- a/rs-csv-importer.php
+++ b/rs-csv-importer.php
@@ -135,31 +135,33 @@ class RS_CSV_Importer extends WP_Importer {
 		} else {
 			$h = RSCSV_Import_Post_Helper::add($post);
 		}
-		
+
 		// Set post tags
 		if (isset($post_tags)) {
 			$h->setPostTags($post_tags);
 		}
-		
+
 		// Set meta data
 		$h->setMeta($meta);
-		
+
 		// Set terms
 		foreach ($terms as $key => $value) {
 			$h->setObjectTerms($key, $value);
 		}
-		
+
 		// Add thumbnail
 		if ($thumbnail) {
 			$h->addThumbnail($thumbnail);
 		}
-		
+
 		return $h;
 	}
 
 	// process parse csv ind insert posts
 	function process_posts() {
-		$h = new RS_CSV_Helper;
+		$helper_class = apply_filters( 'really_simple_csv_helper_class', 'RS_CSV_Helper' );
+
+		$h = new $helper_class();
 
 		$handle = $h->fopen($this->file, 'r');
 		if ( $handle == false ) {


### PR DESCRIPTION
This change allows the `RS_CSV_Helper` class to be customised with a new `really_simple_csv_helper_class` filter - the same way as the `really_simple_csv_importer_class` filter works.

My reason for doing this is that I am importing taxonomy data rather than posts and the importer will report an 'invalid post type' error. I also want to trim white space from the column headings.
